### PR TITLE
Feature: Site scoping for MQTT brokers, webhooks and external feeds (#182)

### DIFF
--- a/capcomposer/src/capcomposer/cap/external_feed/models.py
+++ b/capcomposer/src/capcomposer/cap/external_feed/models.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import ValidationError
 from django.core.validators import MinValueValidator, MaxValueValidator
 from django.db import models
 from django.db.models.signals import post_save, post_delete
@@ -5,6 +6,7 @@ from django.dispatch import receiver
 from django.utils.translation import gettext_lazy as _
 from django_celery_beat.models import PeriodicTask
 from wagtail.admin.panels import FieldPanel
+from wagtail.models import Site
 
 
 class ExternalAlertFeed(models.Model):
@@ -34,6 +36,15 @@ class ExternalAlertFeed(models.Model):
                                                                              " for moderation"),
                                                 help_text=_("Check to automatically submit imported alerts "
                                                             "for moderation. Otherwise, alerts will be saved as drafts."))
+    site = models.ForeignKey(
+        Site,
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="external_feeds",
+        help_text=_("The site this feed is associated with."),
+        verbose_name=_("Site"),
+    )
     
     panels = [
         FieldPanel('name'),
@@ -42,8 +53,15 @@ class ExternalAlertFeed(models.Model):
         FieldPanel('check_interval'),
         FieldPanel('validate_xml_signature'),
         FieldPanel('submit_for_moderation'),
+        FieldPanel('site'),
     ]
     
+    def clean(self):
+        if not self.site_id:
+            raise ValidationError({
+                "site": _("A site must be selected for this feed.")
+            })
+
     class Meta:
         verbose_name = _("External Alert Feed")
         verbose_name_plural = _("External Alert Feeds")

--- a/capcomposer/src/capcomposer/cap/external_feed/utils.py
+++ b/capcomposer/src/capcomposer/cap/external_feed/utils.py
@@ -14,6 +14,14 @@ logger = logging.getLogger(__name__)
 def fetch_and_process_feed(feed_id):
     # get feed by id
     external_feed = ExternalAlertFeed.objects.get(id=feed_id)
+
+    if not external_feed.site_id:
+        logger.error(
+            f"[EXTERNAL FEED] Feed '{external_feed.name}' has no site configured. "
+            "Set a site on the feed before it can import alerts."
+        )
+        return
+
     url = external_feed.url
     submit_for_moderation = external_feed.submit_for_moderation
     
@@ -75,7 +83,11 @@ def fetch_and_process_feed(feed_id):
         
         logger.info(f"[EXTERNAL FEED] Creating draft alert from CAP alert data for {entry_link}")
         # create draft alert page from alert data
-        imported_alert = create_draft_alert_from_alert_data(alert_data, submit_for_moderation=submit_for_moderation)
+        imported_alert = create_draft_alert_from_alert_data(
+            alert_data,
+            site=external_feed.site,
+            submit_for_moderation=submit_for_moderation,
+        )
         
         logger.info(f"[EXTERNAL FEED] Creating ExternalAlertFeedEntry for {entry_link}")
         if imported_alert:

--- a/capcomposer/src/capcomposer/cap/migrations/0034_site_scoping.py
+++ b/capcomposer/src/capcomposer/cap/migrations/0034_site_scoping.py
@@ -1,0 +1,65 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+def assign_default_site(apps, schema_editor):
+    Site = apps.get_model('wagtailcore', 'Site')
+    default_site = Site.objects.filter(is_default_site=True).first()
+    if not default_site:
+        return
+
+    CAPAlertMQTTBroker = apps.get_model('cap', 'CAPAlertMQTTBroker')
+    CAPAlertWebhook = apps.get_model('cap', 'CAPAlertWebhook')
+    ExternalAlertFeed = apps.get_model('cap', 'ExternalAlertFeed')
+
+    CAPAlertMQTTBroker.objects.filter(site__isnull=True).update(site=default_site)
+    CAPAlertWebhook.objects.filter(site__isnull=True).update(site=default_site)
+    ExternalAlertFeed.objects.filter(site__isnull=True).update(site=default_site)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('cap', '0033_capalertwebhook_header_value_and_more'),
+        ('wagtailcore', '0094_alter_page_locale'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='capalertmqttbroker',
+            name='site',
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name='mqtt_brokers',
+                to='wagtailcore.site',
+                verbose_name='Site',
+            ),
+        ),
+        migrations.AddField(
+            model_name='capalertwebhook',
+            name='site',
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name='webhooks',
+                to='wagtailcore.site',
+                verbose_name='Site',
+            ),
+        ),
+        migrations.AddField(
+            model_name='externalalertfeed',
+            name='site',
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name='external_feeds',
+                to='wagtailcore.site',
+                verbose_name='Site',
+            ),
+        ),
+        migrations.RunPython(assign_default_site, migrations.RunPython.noop),
+    ]

--- a/capcomposer/src/capcomposer/cap/mqtt/models.py
+++ b/capcomposer/src/capcomposer/cap/mqtt/models.py
@@ -3,6 +3,7 @@ from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 from wagtail.admin.panels import FieldPanel, MultiFieldPanel
+from wagtail.models import Site
 
 from .utils import encrypt_password
 
@@ -43,6 +44,15 @@ class CAPAlertMQTTBroker(models.Model):
                                                "before proceeding."))
     active = models.BooleanField(default=True, verbose_name=_("Active"),
                                  help_text=_("Automatically publish CAP alerts to this broker"))
+    site = models.ForeignKey(
+        Site,
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="mqtt_brokers",
+        help_text=_("The site this broker is associated with."),
+        verbose_name=_("Site"),
+    )
     created = models.DateTimeField(auto_now_add=True)
     modified = models.DateTimeField(auto_now=True)
     retry_on_failure = models.BooleanField(default=True, verbose_name=_("Retry on failure"))
@@ -61,6 +71,7 @@ class CAPAlertMQTTBroker(models.Model):
         FieldPanel("wis2box_metadata_id"),
         FieldPanel("topic"),
         FieldPanel("active"),
+        FieldPanel("site"),
     ]
     
     def clean(self):
@@ -89,6 +100,11 @@ class CAPAlertMQTTBroker(models.Model):
         if not self.password and not self.new_password:
             raise ValidationError({
                 "new_password": _("Password is required if creating a new broker")
+            })
+
+        if not self.site_id:
+            raise ValidationError({
+                "site": _("A site must be selected for this broker.")
             })
     
     def save(self, *args, **kwargs):

--- a/capcomposer/src/capcomposer/cap/mqtt/publish.py
+++ b/capcomposer/src/capcomposer/cap/mqtt/publish.py
@@ -27,38 +27,42 @@ def publish_cap_to_all_mqtt_brokers(cap_alert_id):
     
     logging.info(
         f"Starting publish_cap_to_all_mqtt_brokers for CAP Alert ID: {cap_alert_id}")
-    
-    # Get all active brokers
-    brokers = CAPAlertMQTTBroker.objects.filter(active=True)
-    
-    if not brokers:
-        logging.warning("No MQTT brokers found")
-        return
-    
+
     # Get the cap alert data to be published
     cap_alert = get_object_or_none(CapAlertPage, id=cap_alert_id)
     logging.info(f"CAP Alert: {cap_alert} found")
-    
+
     if not cap_alert:
         logging.warning(f"CAP Alert: {cap_alert_id} not found")
         return
-    
+
     if not cap_alert.live:
         logging.warning(f"CAP Alert: {cap_alert_id} is not published")
         return
-    
+
     if cap_alert.status != "Actual":
         logging.warning(f"CAP Alert: {cap_alert_id} is not actionable")
         return
-    
+
+    site = cap_alert.get_site()
+    if not site:
+        logging.warning(f"CAP Alert: {cap_alert_id} has no associated site, skipping MQTT publish")
+        return
+
+    brokers = CAPAlertMQTTBroker.objects.filter(active=True, site=site)
+
+    if not brokers:
+        logging.warning("No MQTT brokers found")
+        return
+
     # Get the processed CAP alert XML
     alert_xml, signed = serialize_and_sign_cap_alert(cap_alert)
-    
+
     if not signed:
         logging.warning(f"CAP Alert: {cap_alert_id} not signed")
         # Continue to publish anyway, the acceptance/rejection of non-signed
         # alerts should be handled on the receiving side (e.g. a wis2box)
-    
+
     for broker in brokers:
         publish_cap_to_each_mqtt_broker(cap_alert, alert_xml, broker)
 

--- a/capcomposer/src/capcomposer/cap/utils.py
+++ b/capcomposer/src/capcomposer/cap/utils.py
@@ -292,18 +292,23 @@ def get_cap_audience_list_for_site(site):
 def create_draft_alert_from_alert_data(
         alert_data,
         request=None,
+        site=None,
         update_event_list=False,
         update_contact_list=False,
         submit_for_moderation=False,
         include_guid=False
 ):
     from .models import CapAlertPage, CapAlertListPage
-    
-    if request:
+
+    if site:
+        resolved_site = site
+        cap_settings = CapSetting.for_site(site)
+    elif request:
+        resolved_site = Site.find_for_request(request)
         cap_settings = CapSetting.for_request(request)
     else:
-        site = Site.objects.get(is_default_site=True)
-        cap_settings = CapSetting.for_site(site)
+        resolved_site = Site.objects.filter(is_default_site=True).first()
+        cap_settings = CapSetting.for_site(resolved_site)
     
     base_data = {
         "imported": True,  # mark this alert page as imported
@@ -510,7 +515,12 @@ def create_draft_alert_from_alert_data(
     new_cap_alert_page = CapAlertPage(**base_data, live=False)
     new_cap_alert_page.info = StreamValue(new_cap_alert_page.info.stream_block, info_blocks, is_lazy=True)
     
-    cap_list_page = CapAlertListPage.objects.live().first()
+    if resolved_site:
+        cap_list_page = CapAlertListPage.objects.live().descendant_of(
+            resolved_site.root_page, inclusive=True
+        ).first()
+    else:
+        cap_list_page = CapAlertListPage.objects.live().first()
     
     if cap_list_page:
         cap_list_page.add_child(instance=new_cap_alert_page)

--- a/capcomposer/src/capcomposer/cap/wagtail_hooks.py
+++ b/capcomposer/src/capcomposer/cap/wagtail_hooks.py
@@ -178,6 +178,10 @@ class CAPAlertWebhookAdmin(ModelAdmin):
     model = CAPAlertWebhook
     menu_label = _('Webhooks')
     menu_icon = 'multi-cluster-sector'
+    
+    def get_queryset(self, request):
+        site = Site.find_for_request(request)
+        return super().get_queryset(request).filter(site=site)
 
 
 class CAPAlertWebhookEventPermissionHelper(PermissionHelper):
@@ -203,6 +207,10 @@ class CAPAlertWebhookEventAdmin(ModelAdmin):
     inspect_view_enabled = True
     
     permission_helper_class = CAPAlertWebhookEventPermissionHelper
+    
+    def get_queryset(self, request):
+        site = Site.find_for_request(request)
+        return super().get_queryset(request).filter(webhook__site=site)
 
 
 class CAPAlertMQTTAdmin(ModelAdmin):
@@ -214,6 +222,10 @@ class CAPAlertMQTTAdmin(ModelAdmin):
     search_fields = ('name', 'wis2box_metadata_id')
     
     form_view_extra_js = ['cap/js/mqtt_collapse_panels.js']
+    
+    def get_queryset(self, request):
+        site = Site.find_for_request(request)
+        return super().get_queryset(request).filter(site=site)
 
 
 class CAPAlertMQTTEventPermissionHelper(PermissionHelper):
@@ -239,12 +251,20 @@ class CAPAlertMQTTEventAdmin(ModelAdmin):
     inspect_view_enabled = True
     
     permission_helper_class = CAPAlertMQTTEventPermissionHelper
+    
+    def get_queryset(self, request):
+        site = Site.find_for_request(request)
+        return super().get_queryset(request).filter(broker__site=site)
 
 
 class CAPExternalFeedAdmin(ModelAdmin):
     model = ExternalAlertFeed
     menu_label = _('External CAP Alert Feeds')
     menu_icon = 'link'
+    
+    def get_queryset(self, request):
+        site = Site.find_for_request(request)
+        return super().get_queryset(request).filter(site=site)
 
 
 class CAPMenuGroupAdminMenuItem(GroupMenuItem):
@@ -461,8 +481,10 @@ def before_delete_cap_alert_page(request, page):
 
 
 @hooks.register("before_import_cap_alert")
-def import_cap_alert(request, alert_data, include_guid=False):
-    new_cap_alert_page = create_draft_alert_from_alert_data(alert_data, request, include_guid=include_guid)
+def import_cap_alert(request, alert_data, include_guid=False, site=None):
+    new_cap_alert_page = create_draft_alert_from_alert_data(
+        alert_data, request, site=site, include_guid=include_guid
+    )
     
     if not new_cap_alert_page:
         return None

--- a/capcomposer/src/capcomposer/cap/webhook/models.py
+++ b/capcomposer/src/capcomposer/cap/webhook/models.py
@@ -1,7 +1,9 @@
+from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 from modelcluster.models import ClusterableModel
 from wagtail.admin.panels import FieldPanel
+from wagtail.models import Site
 
 
 class CAPAlertWebhook(ClusterableModel):
@@ -13,15 +15,30 @@ class CAPAlertWebhook(ClusterableModel):
     retry_on_failure = models.BooleanField(default=True, verbose_name=_("Retry on failure"))
     include_auth_header = models.BooleanField(default=False, verbose_name=_("Include Header for Authentication"))
     header_value = models.CharField(max_length=255, blank=True, null=True, verbose_name=_("Header Value"))
-    
+    site = models.ForeignKey(
+        Site,
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="webhooks",
+        verbose_name=_("Site"),
+    )
+
     panels = [
         FieldPanel("name"),
         FieldPanel("url"),
         FieldPanel("include_auth_header"),
         FieldPanel("header_value"),
         FieldPanel("active"),
+        FieldPanel("site"),
     ]
     
+    def clean(self):
+        if not self.site_id:
+            raise ValidationError({
+                "site": _("A site must be selected for this webhook.")
+            })
+
     class Meta:
         verbose_name = _("CAP Alert Webhook")
         verbose_name_plural = _("CAP Alert Webhooks")

--- a/capcomposer/src/capcomposer/cap/webhook/utils.py
+++ b/capcomposer/src/capcomposer/cap/webhook/utils.py
@@ -13,15 +13,9 @@ from .http import prepare_request
 def fire_alert_webhooks(cap_alert_id):
     from capcomposer.cap.models import CapAlertPage
     from .models import CAPAlertWebhook, CAPAlertWebhookEvent
-    
-    webhooks = CAPAlertWebhook.objects.filter(active=True)
-    
-    if not webhooks:
-        logging.warning("No active webhooks found")
-        return
-    
+
     cap_alert = get_object_or_none(CapAlertPage, id=cap_alert_id)
-    
+
     if not cap_alert:
         logging.warning(f"CAP Alert: {cap_alert_id} not found")
         return
@@ -33,9 +27,20 @@ def fire_alert_webhooks(cap_alert_id):
     if not cap_alert.status == "Actual" and not cap_alert.scope == "Public":
         logging.warning(f"CAP Alert: {cap_alert_id} is not Public")
         return
-    
+
+    site = cap_alert.get_site()
+    if not site:
+        logging.warning(f"CAP Alert: {cap_alert_id} has no associated site, skipping webhook fire")
+        return
+
+    webhooks = CAPAlertWebhook.objects.filter(active=True, site=site)
+
+    if not webhooks:
+        logging.warning("No active webhooks found")
+        return
+
     alert_xml, signed = serialize_and_sign_cap_alert(cap_alert)
-    
+
     for webhook in webhooks:
         req = prepare_request(webhook, alert_xml)
         

--- a/capcomposer/src/capcomposer/capeditor/forms/capimporter.py
+++ b/capcomposer/src/capcomposer/capeditor/forms/capimporter.py
@@ -1,6 +1,7 @@
 import requests
 from django import forms
 from django.utils.translation import gettext_lazy as _
+from wagtail.models import Site
 
 from capcomposer.capeditor.caputils import cap_xml_to_alert_data
 from capcomposer.capeditor.errors import CAPImportError
@@ -12,17 +13,26 @@ class CAPLoadForm(forms.Form):
         ('url', _('URL')),
         ('file', _('File')),
     )
-    
+
     load_from = forms.ChoiceField(choices=LOAD_FROM_CHOICES, initial="text", widget=forms.RadioSelect,
                                   label=_('Load from'), )
     text = forms.CharField(required=False, widget=forms.Textarea, label=_('Paste your CAP XML here'))
     url = forms.URLField(required=False, label=_('CAP Alert XML URL'))
     file = forms.FileField(required=False, label=_('CAP File'))
     include_guid = forms.BooleanField(required=False, label=_('Include GUID'))
-    
-    def __init__(self, *args, **kwargs):
+    site = forms.ModelChoiceField(
+        queryset=Site.objects.all(),
+        label=_('Site'),
+        help_text=_('Select the site to import this alert into.'),
+    )
+
+    def __init__(self, *args, request=None, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields['file'].widget.attrs.update({'accept': '.xml'})
+        if request:
+            current_site = Site.find_for_request(request)
+            if current_site:
+                self.initial['site'] = current_site.pk
     
     def clean(self):
         cleaned_data = super().clean()
@@ -85,3 +95,8 @@ class CAPLoadForm(forms.Form):
 class CAPImportForm(forms.Form):
     alert_data = forms.JSONField(widget=forms.HiddenInput)
     include_guid = forms.BooleanField(required=True, label=_('Include GUID'), widget=forms.HiddenInput)
+    site = forms.ModelChoiceField(
+        queryset=Site.objects.all(),
+        widget=forms.HiddenInput,
+        required=False,
+    )

--- a/capcomposer/src/capcomposer/capeditor/templates/capeditor/load_cap_alert.html
+++ b/capcomposer/src/capcomposer/capeditor/templates/capeditor/load_cap_alert.html
@@ -25,10 +25,10 @@
             {% endif %}
             {% csrf_token %}
             {% for field in form %}
-                {% if field.name != "load_from" and field.name != "include_guid" %}
-                    {% include "wagtailadmin/shared/field.html" with classname="w-hidden" %}
-                {% else %}
+                {% if field.name == "load_from" or field.name == "include_guid" or field.name == "site" %}
                     {% include "wagtailadmin/shared/field.html" %}
+                {% else %}
+                    {% include "wagtailadmin/shared/field.html" with classname="w-hidden" %}
                 {% endif %}
             {% endfor %}
 

--- a/capcomposer/src/capcomposer/capeditor/views.py
+++ b/capcomposer/src/capcomposer/capeditor/views.py
@@ -18,25 +18,26 @@ def load_cap_alert(request):
     context = {}
     
     if request.method == "POST":
-        form = CAPLoadForm(request.POST, request.FILES)
+        form = CAPLoadForm(request.POST, request.FILES, request=request)
         if form.is_valid():
             alert_data = form.cleaned_data["alert_data"]
             include_guid = form.cleaned_data["include_guid"]
-            
-            form = CAPImportForm(initial={"alert_data": alert_data, "include_guid": include_guid})
+            site = form.cleaned_data["site"]
+
+            form = CAPImportForm(initial={"alert_data": alert_data, "include_guid": include_guid, "site": site})
             context.update({
                 "alert_data": alert_data,
                 "form": form,
                 "include_guid": include_guid,
             })
-            
+
             return render(request, preview_template_name, context)
-        
+
         else:
             context.update({"form": form})
             return render(request, template_name=load_template_name, context=context)
-    
-    form = CAPLoadForm()
+
+    form = CAPLoadForm(request=request)
     context.update({"form": form})
     
     return render(request, load_template_name, context)
@@ -48,10 +49,11 @@ def import_cap_alert(request):
         if form.is_valid():
             alert_data = form.cleaned_data["alert_data"]
             include_guid = form.cleaned_data["include_guid"]
-            
+            site = form.cleaned_data["site"]
+
             # run hook to import alert
             for fn in hooks.get_hooks("before_import_cap_alert"):
-                result = fn(request, alert_data, include_guid)
+                result = fn(request, alert_data, include_guid, site=site)
                 if hasattr(result, "status_code"):
                     return result
             

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -11,7 +11,7 @@ x-capcomposer-variables: &capcomposer-variables
   ALLOWED_HOSTS: ${ALLOWED_HOSTS:-127.0.0.1,localhost}
   CSRF_TRUSTED_ORIGINS: ${CSRF_TRUSTED_ORIGINS:-http://127.0.0.1,http://localhost}
   DATABASE_URL: postgis://${DB_USER}:${DB_PASSWORD}@capcomposer_db:5432/${DB_NAME}
-  REDIS_URL: redis://:${REDIS_PASSWORD:?}@capcomposer__redis:6379/0
+  REDIS_URL: redis://:${REDIS_PASSWORD:?}@capcomposer_redis:6379/0
   EMAIL_SMTP: ${EMAIL_SMTP:-}
   EMAIL_SMTP_HOST: ${EMAIL_SMTP_HOST:-}
   EMAIL_SMTP_PORT: ${EMAIL_SMTP_PORT:-}


### PR DESCRIPTION
Closes #182

## Summary

- Add `site` ForeignKey to `CAPAlertMQTTBroker`, `CAPAlertWebhook`, and `ExternalAlertFeed` so each resource is scoped to a specific site in a multisite setup
- Filter brokers/webhooks by the alert's site at publish/fire time, preventing alerts from being sent to all sites' endpoints
- Scope admin listings for MQTT brokers, broker events, webhooks, webhook events, and external feeds to the current site using `Site.find_for_request(request)`
- Fix external feed importer to place imported alerts in the correct site's page tree instead of always using the first `CapAlertListPage`
- Add `clean()` validation on all three models requiring a site to be selected before saving
- Add a site picker to the CAP import form, defaulting to the current site, threaded through the preview step into the import hook
- Data migration assigns all existing records to the default site

## Test plan

- [ ] On a multisite setup, create MQTT brokers for two different sites — verify each site's admin only shows its own brokers
- [ ] Publish an alert on site A — verify it only fires to site A's active brokers/webhooks, not site B's
- [ ] Attempt to save a broker/webhook/feed without selecting a site — verify validation error appears on the `site` field
- [ ] Configure an external feed on site B — verify imported alerts appear under site B's alert list page
- [ ] Use the Import CAP Alert form — verify the site picker defaults to the current site and the imported alert lands on the selected site
- [ ] On a single-site setup, verify existing behaviour is unchanged