### PR TITLE
Bump adm-boundary-manager to 0.3.0 and register boundary viewset

### DIFF
--- a/capcomposer/requirements/base.txt
+++ b/capcomposer/requirements/base.txt
@@ -4,7 +4,7 @@ python-magic
 shapely
 wagtail-icon-chooser>=0.3.2
 wagtail-cache==3.0.0
-adm-boundary-manager>=0.2.5
+adm-boundary-manager>=0.3.0
 wagtail-humanitarian-icons>=2.0.0
 wagtail-modelchooser>=4.0.1
 paho-mqtt>=2.1.0

--- a/capcomposer/src/capcomposer/home/wagtail_hooks.py
+++ b/capcomposer/src/capcomposer/home/wagtail_hooks.py
@@ -1,7 +1,7 @@
-# from adminboundarymanager.wagtail_hooks import AdminBoundaryViewSetGroup
-# from wagtail_modeladmin.options import (
-#     modeladmin_register
-# )
+from adminboundarymanager.wagtail_hooks import AdminBoundaryViewSetGroup
+from wagtail import hooks
 
-# modeladmin_register(AdminBoundaryViewSetGroup)
-from wagtail_modeladmin.options import modeladmin_register
+
+@hooks.register("register_admin_viewset")
+def register_admin_boundary_viewset():
+    return AdminBoundaryViewSetGroup()


### PR DESCRIPTION
## Summary

- Require `adm-boundary-manager>=0.3.0`, which replaces the ModelAdmin-based `AdminBoundaryManagerAdminGroup` with `AdminBoundaryViewSetGroup`
- Register the viewset group via the `register_admin_viewset` hook instead of `modeladmin_register`, which is incompatible with `ViewSetGroup` (it calls `register_with_wagtail()`, which ViewSetGroups don't have)

## Test plan

- Verified Django boots cleanly with adm-boundary-manager 0.3.0 installed
- Verified `capcomposer.home.wagtail_hooks` imports without errors
- Verified the boundary loader URL reverses to `/cap-admin/preview-boundary/`
- The "Boundaries" group appears in the Wagtail admin menu via the viewset group's `add_to_admin_menu = True`