### PR TITLE
Freeze `sent` once an alert is disseminated

### DIFF
--- a/capcomposer/src/capcomposer/cap/models.py
+++ b/capcomposer/src/capcomposer/cap/models.py
@@ -435,12 +435,34 @@ class CapAlertPage(MetadataPageMixin, NewsletterPageMixin, AbstractCapAlertPage)
         return context
     
     def save(self, *args, **kwargs):
-        # if not imported, set the sent date as now
+        # `sent` is the CAP dissemination time, and — when the site has a WMO OID
+        # configured — <identifier> is derived from it (see CapAlertPage.identifier).
+        # Both must be frozen the moment the alert goes out: a message that is
+        # re-serialized with a later `sent` is a *different* CAP message to every
+        # consumer, so it forks into a duplicate alert downstream, and any
+        # previously-issued Update/Cancel referencing the old identifier dangles.
+        #
+        # Stamping is therefore restricted to alerts that are not yet live in the
+        # database. Wagtail sets `self.live = True` in memory *before* calling
+        # save() (wagtail/actions/publish_revision.py), so the in-memory flag
+        # cannot distinguish a first publish from a re-publish — only the stored
+        # row can. Drafts are unaffected either way: Wagtail persists them with
+        # save(update_fields=["latest_revision"]).
+        #
+        # This also protects against the saves made *after* publication by
+        # create_cap_alert_multi_media(), which previously pushed `sent` minutes
+        # past the real dissemination time whenever map/PDF rendering crossed a
+        # minute boundary.
         if not self.imported:
-            # use current time. Replace seconds and microseconds to 0
-            sent = timezone.now().replace(second=0, microsecond=0)
-            self.sent = sent
-        
+            already_disseminated = (
+                self.pk is not None
+                and CapAlertPage.objects.filter(pk=self.pk, live=True).exists()
+            )
+            if not already_disseminated:
+                # use current time. Replace seconds and microseconds to 0
+                sent = timezone.now().replace(second=0, microsecond=0)
+                self.sent = sent
+
         return super().save(*args, **kwargs)
 
 

--- a/capcomposer/src/capcomposer/cap/utils.py
+++ b/capcomposer/src/capcomposer/cap/utils.py
@@ -149,16 +149,20 @@ def create_cap_alert_multi_media(cap_alert_page_id, clear_cache_on_success=False
     logger.info(f"[CAP] Generating CAP Alert MultiMedia content for: {cap_alert.title} ")
     # create alert area map image
     cap_alert_area_map_image = create_alert_area_image(cap_alert.id)
-    
+
+    # These saves run *after* the alert has been disseminated, and map/PDF
+    # rendering takes long enough to cross a wall-clock minute. Narrow them to the
+    # media field each one actually sets, so nothing here can ever rewrite `sent`
+    # (and with it <identifier>) out from under an already-published alert.
     if cap_alert_area_map_image:
         logger.info(f"[CAP] CAP Alert Area Map Image created for: {cap_alert.title}")
         cap_alert.alert_area_map_image = cap_alert_area_map_image
-        cap_alert.save()
-        
+        cap_alert.save(update_fields=["alert_area_map_image"])
+
         # create_cap_pdf_document
         cap_preview_document = create_cap_pdf_document(cap_alert, template_name="cap/alert_detail_pdf.html")
         cap_alert.alert_pdf_preview = cap_preview_document
-        cap_alert.save()
+        cap_alert.save(update_fields=["alert_pdf_preview"])
         
         logger.info(f"[CAP] CAP Alert PDF Document created for: {cap_alert.title}")
         
@@ -177,7 +181,7 @@ def create_cap_alert_multi_media(cap_alert_page_id, clear_cache_on_success=False
         
         if cap_preview_image:
             cap_alert.search_image = cap_preview_image
-            cap_alert.save()
+            cap_alert.save(update_fields=["search_image"])
         
         logger.info(f"[CAP] CAP Alert MultiMedia content saved for: {cap_alert.title}")
         
@@ -208,19 +212,20 @@ def send_private_alert_email(alert_id):
                     "name": name
                 })
         
-        # Generate image if not available
+        # Generate image if not available (narrow save — see
+        # create_cap_alert_multi_media: post-publish saves must not touch `sent`)
         if not alert.alert_area_map_image or not alert.alert_area_map_image.file:
             image = create_alert_area_image(alert.id)
             if image:
                 alert.alert_area_map_image = image
-                alert.save()
-        
+                alert.save(update_fields=["alert_area_map_image"])
+
         # Generate PDF if not available
         if not alert.alert_pdf_preview or not alert.alert_pdf_preview.file:
             pdf = create_cap_pdf_document(alert, template_name="cap/alert_detail_pdf.html")
             if pdf:
                 alert.alert_pdf_preview = pdf
-                alert.save()
+                alert.save(update_fields=["alert_pdf_preview"])
         
         subject = f"CAP Alert: {alert.title}"
         # Get site base URL

--- a/capcomposer/src/capcomposer/version.py
+++ b/capcomposer/src/capcomposer/version.py
@@ -1,6 +1,6 @@
 # major.minor.patch.release.number
 # release must be one of alpha, beta, rc, or final
-VERSION = (1, 3, 3, "final", 0)
+VERSION = (1, 3, 4, "final", 0)
 
 
 def get_semver_version(version):


### PR DESCRIPTION
## Problem

`CapAlertPage.save()` re-stamped `sent = now().replace(second=0, microsecond=0)` on **every** full save, not only at publication.

Wagtail's publish path calls a full `save()`, and the `page_published` signal then fires `handle_generate_multimedia`, whose `create_cap_alert_multi_media()` saves the page **three more times** — once per generated asset. Map render + PDF build + PDF→JPG rasterisation comfortably crosses a wall-clock minute, so `sent` moved *after* the alert had already gone out over MQTT and the feed.

That is not cosmetic drift. `sent` is the CAP dissemination time, and `CapAlertPage.identifier` derives from it whenever the site has a WMO OID configured:

```python
@property
def identifier(self):
    if cap_setting.wmo_oid:
        return format_date_to_oid(cap_setting.wmo_oid, self.sent)   # urn:oid:<prefix>.Y.M.D.h.m.s
    return str(self.guid)
```

So the alert's **identifier silently changed too**.

## Observed impact

This was found from the downstream end. A CAP aggregator polling an NMHS feed ended up holding **two live alerts for the same hazard in the same country**, identical but for a `<sent>` one minute apart (07:53 and 07:54), while the feed itself listed only 07:54.

A moved identity triple is an entirely new CAP message with no `<references>` back to the original, so every layer downstream agreed it was a new alert: different bytes, different `(sender, identifier, sent)` triple, nothing for a lineage resolver to join on. Two chains, two resolved alerts, two polygons on the map.

There is a second consequence: `<references>` is computed from the referenced page's *current* identifier (`capeditor/blocks.py`), so any alert whose `sent` moved has stranded previously-issued Update/Cancel messages pointing at a message nobody ever published.

## Changes

- **Stamp `sent` only while the alert is not yet live in the database.** Wagtail sets `self.live = True` in memory *before* calling `save()` (`wagtail/actions/publish_revision.py`), so the in-memory flag cannot distinguish a first publish from a re-publish — only the stored row can. Drafts are unaffected either way, since Wagtail persists them with `save(update_fields=["latest_revision"])`.
- **Narrow every post-publish save** in `create_cap_alert_multi_media()` and `send_private_alert_email()` to the media field it actually sets, so nothing after dissemination can rewrite `sent` even if the guard above ever regresses.
- Version bump to 1.3.4.

Scheduled publishing keeps working as intended: a page with a future `go_live_at` is not live, so it stamps `sent` at the moment it actually goes live.

## Testing

⚠️ **No regression test.** This app has no test suite — `cap/tests.py` is the empty Django stub — and no fixture for building a Wagtail page tree, so the publish path cannot be exercised without standing up test infrastructure first. The change is verified by reading Wagtail's publish control flow, not by execution. Worth a careful review on that basis, and worth manual verification against a real publish + multimedia cycle before release.

The downstream half of this fix (detecting and quarantining such re-issues in cap-aggregator, where the behaviour *is* covered by tests) is tracked separately.
